### PR TITLE
Basic CMake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Build dirs
+build/
+
 *.o
 *.a
 .directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+project (smelt)
+
+cmake_minimum_required(VERSION 3.11)
+
+option (BUILD_DUMB "Disable sound support" OFF)
+option (BUILD_EXTENSIONS "Build extensions" ON)
+
+add_subdirectory(smelt/glfw)
+
+if (BUILD_EXTENSIONS)
+	add_subdirectory(extensions)
+endif ()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.11)
 
 option (BUILD_DUMB "Disable sound support" OFF)
 option (BUILD_EXTENSIONS "Build extensions" ON)
+option (USE_CXIMAGE "Use CxImage instead of DevIL" OFF)
+option (BUILD_EXAMPLE "Build example" ON)
 
 add_subdirectory(smelt/glfw)
 
@@ -11,3 +13,6 @@ if (BUILD_EXTENSIONS)
 	add_subdirectory(extensions)
 endif ()
 
+if (BUILD_EXAMPLE)
+	add_subdirectory(examples)
+endif ()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,11 +2,18 @@ option (USE_CXIMAGE "Use CxImage instead of DevIL" OFF)
 
 find_package(glfw3 3.2 REQUIRED)
 find_package(GLEW REQUIRED)
-find_package(OpenAL REQUIRED)
 find_package(Freetype REQUIRED)
+find_package(ZLIB REQUIRED)
 
 if (NOT USE_CXIMAGE)
         find_package(DevIL REQUIRED)
+endif ()
+
+if (NOT BUILD_DUMB)
+	find_package(PkgConfig REQUIRED)
+	find_package(OpenAL REQUIRED)
+	pkg_search_module(VORBISFILE vorbisfile REQUIRED)
+	pkg_search_module(VORBIS vorbis REQUIRED)
 endif ()
 
 add_executable(example
@@ -18,12 +25,21 @@ include_directories(
         ${FREETYPE_INCLUDE_DIRS}
 )
 
+if (NOT USE_CXIMAGE)
+        target_link_libraries(example ${IL_LIBRARIES})
+endif ()
+
+if (NOT BUILD_DUMB)
+	target_link_libraries(example ${OPENAL_LIBRARY} ${VORBISFILE_LIBRARIES} ${VORBIS_LIBRARIES})
+endif ()
+
 target_link_libraries(example
+	smelt smeltext
 	glfw
 	${GLEW_LIBRARIES}
-	${OpenAL_LIBRARIES}
 	${FREETYPE_LIBRARIES}
-	smelt smeltext 
+	${ZLIB_LIBRARIES}
+	GL
 )
 
 get_cmake_property(__cmake_debug_var VARIABLES)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,32 @@
+option (USE_CXIMAGE "Use CxImage instead of DevIL" OFF)
+
+find_package(glfw3 3.2 REQUIRED)
+find_package(GLEW REQUIRED)
+find_package(OpenAL REQUIRED)
+find_package(Freetype REQUIRED)
+
+if (NOT USE_CXIMAGE)
+        find_package(DevIL REQUIRED)
+endif ()
+
+add_executable(example
+	smelt_test.cpp)
+
+include_directories(
+	${GLFW_INCLUDE_DIRS}
+        ${GLEW_INCLUDE_DIRS}
+        ${FREETYPE_INCLUDE_DIRS}
+)
+
+target_link_libraries(example
+	glfw
+	${GLEW_LIBRARIES}
+	${OpenAL_LIBRARIES}
+	${FREETYPE_LIBRARIES}
+	smelt smeltext 
+)
+
+get_cmake_property(__cmake_debug_var VARIABLES)
+foreach (__var ${__cmake_debug_var})
+	message(STATUS ">>> ${__var}=${${__var}}")
+endforeach ()

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -1,10 +1,11 @@
 find_package(Freetype REQUIRED)
 
-file (GLOB SMELTTEXT_CPP_FILES "*.cpp")
+file (GLOB SMELTEXT_CPP_FILES "*.cpp")
 
 include_directories(
 	${FREETYPE_INCLUDE_DIRS}
-	${CMAKE_CURRENT_SOURCE_DIR}/../include
 )
 
-add_library(smelttext STATIC ${SMELTTEXT_CPP_FILES})
+add_library(smeltext STATIC ${SMELTEXT_CPP_FILES})
+
+target_link_libraries(smeltext smelt)

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -1,0 +1,10 @@
+find_package(Freetype REQUIRED)
+
+file (GLOB SMELTTEXT_CPP_FILES "*.cpp")
+
+include_directories(
+	${FREETYPE_INCLUDE_DIRS}
+	${CMAKE_CURRENT_SOURCE_DIR}/../include
+)
+
+add_library(smelttext STATIC ${SMELTTEXT_CPP_FILES})

--- a/smelt/glfw/CMakeLists.txt
+++ b/smelt/glfw/CMakeLists.txt
@@ -1,10 +1,13 @@
-option(BUILD_DUMB "Disable sound support" OFF)
+option (BUILD_DUMB "Disable sound support" OFF)
+option (USE_CXIMAGE "Use CxImage instead of DevIL" OFF)
 
-find_package(PkgConfig REQUIRED)
+find_package(glfw3 REQUIRED)
 find_package(GLEW REQUIRED)
 find_package(OpenAL REQUIRED)
 
-pkg_search_module(GLFW REQUIRED glfw3)
+if (NOT USE_CXIMAGE)
+	find_package(DevIL REQUIRED)
+endif ()
 
 set (SMELT_GLFW_CPP_FILES
 	gfx_glfw.cpp
@@ -14,11 +17,14 @@ set (SMELT_GLFW_CPP_FILES
 )
 
 include_directories(
-	${GLFW_INCLUDE_DIRS}
 	${GLEW_INCLUDE_DIRS}
 )
 
 add_library(smelt STATIC ${SMELT_GLFW_CPP_FILES})
+
+target_include_directories(smelt PUBLIC ../../include)
+
+target_link_libraries(smelt glfw)
 
 if (BUILD_DUMB)
 	message (STATUS "")
@@ -26,5 +32,14 @@ if (BUILD_DUMB)
 	message (STATUS "")
 	target_compile_definitions(smelt PRIVATE
 		ENABLE_DUMB
+	)
+endif ()
+
+if (USE_CXIMAGE)
+	message (STATUS "")
+	message (STATUS "USE_CXIMAGE build option enabled")
+	message (STATUS "")
+	target_compile_definitions(smelt PRIVATE
+		USE_CXIMAGE
 	)
 endif ()

--- a/smelt/glfw/CMakeLists.txt
+++ b/smelt/glfw/CMakeLists.txt
@@ -1,0 +1,30 @@
+option(BUILD_DUMB "Disable sound support" OFF)
+
+find_package(PkgConfig REQUIRED)
+find_package(GLEW REQUIRED)
+find_package(OpenAL REQUIRED)
+
+pkg_search_module(GLFW REQUIRED glfw3)
+
+set (SMELT_GLFW_CPP_FILES
+	gfx_glfw.cpp
+	sfx_oal.cpp
+	inp_glfw.cpp
+	sys_glfw.cpp
+)
+
+include_directories(
+	${GLFW_INCLUDE_DIRS}
+	${GLEW_INCLUDE_DIRS}
+)
+
+add_library(smelt STATIC ${SMELT_GLFW_CPP_FILES})
+
+if (BUILD_DUMB)
+	message (STATUS "")
+	message (STATUS "BUILD_DUMB build option enabled")
+	message (STATUS "")
+	target_compile_definitions(smelt PRIVATE
+		ENABLE_DUMB
+	)
+endif ()


### PR DESCRIPTION
Something TBD:

 - **CxImage not build**
There are two copy of CxImage in the source code and I'm not sure what's the differences. It's also seems the SMELT codebase itself does not use the CxImage library at all.
 - **glfw version only**
Should be easy to add if we need also build the sdl version.
 - **tools not build**
Did we need to do that?
 - **dumb version are not build at the same time with the non-dumb version**
a CMake option `BUILD_DUMB` is used to enable or disable sound support
 - **example not build**
since it requires CxImage to build.
 - **no `make install` support**
will not help user copy the .a file to the right FHS location, nor the include folder.